### PR TITLE
fix: load new spec if attribute changed

### DIFF
--- a/src/rapidoc.js
+++ b/src/rapidoc.js
@@ -575,7 +575,7 @@ export default class RapiDoc extends LitElement {
   } */
 
   attributeChangedCallback(name, oldVal, newVal) {
-    if (name === 'spec-url') {
+    if (name === 'spec-url' || name === 'spec') {
       if (oldVal !== newVal) {
         // put it at the end of event-loop to load all the attributes
         window.setTimeout(async () => {


### PR DESCRIPTION
#### What is the purpose of this pull request?

To load new open API documentation if the spec attribute changed.

#### What problem is this solving?

The spec did not update correctly.

#### How should this be manually tested?

Change between API Reference pages and check if the documentation updates.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
