### PR TITLE
fix: add postman button to overview

### DIFF
--- a/src/templates/overview-template.js
+++ b/src/templates/overview-template.js
@@ -4,6 +4,8 @@ import { marked } from 'marked';
 import processPathDescription from '../utils/magic-block-utils';
 import { downloadResource, viewResource } from '../utils/common-utils';
 import renderBlockquote from '../utils/renderBlockquote';
+import postmanIcon from '../components/assets/postman-icon';
+import openapiIcon from '../components/assets/openapi-icon';
 
 /* eslint-disable indent */
 function headingRenderer() {
@@ -21,14 +23,28 @@ export default function overviewTemplate() {
       <span part="anchor-endpoint" id="overview"></span>
       ${this.resolvedSpec?.info
         ? html`
-          ${this.specUrl && this.allowSpecFileDownload === 'true'
-            ? html`
-              <div style="display:flex; margin-top:18px; gap:8px; justify-content: flex-end; flex-wrap: wrap;">
-                <button class="m-btn thin-border m-btn-tertiary" part="btn btn-outline" @click='${(e) => { downloadResource(this.specUrl, 'openapi-spec', e); }}'>Download OpenAPI spec</button>
-                <button class="m-btn m-btn-secondary thin-border" part="btn btn-outline" @click='${(e) => { viewResource(this.specUrl, e); }}'>View OpenAPI spec</button>
-              </div>`
-            : ''
-          }
+          <div style="display: flex; flex-direction:column; row-gap: 20px; margin-bottom: 24px;">
+            ${(this.specUrl && this.allowSpecFileDownload) ? html`<div><div style="display:flex; justify-content: flex-end; gap:8px; flex-wrap: wrap;">
+                  <button class="m-btn m-btn-image m-btn-tertiary thin-border" style="padding-left: 0;" part="btn btn-outline" @click='${(e) => { downloadResource(this.specUrl, 'openapi-spec.json', e); }}'>
+                    ${openapiIcon()}
+                    Download OpenAPI spec
+                  </button>
+                    <button class="m-btn m-btn-image m-btn-secondary thin-border" part="btn btn-outline" @click='${(e) => { viewResource(this.specUrl, e); }}'>
+                      ${openapiIcon()}
+                      View OpenAPI spec
+                    </button>
+                </div></div>` : ''}
+            ${this.postmanUrl ? html`<div><div style="display:flex; justify-content: flex-end; gap:8px; flex-wrap: wrap;">
+                  <button class="m-btn m-btn-image m-btn-tertiary thin-border" style="padding-left: 0;" part="btn btn-outline" @click='${(e) => { downloadResource(this.postmanUrl, 'postman-collection.json', e); }}'>
+                    ${postmanIcon()}
+                    Download Postman collection
+                  </button>
+                    <button class="m-btn m-btn-image m-btn-secondary thin-border" part="btn btn-outline" @click='${(e) => { viewResource(this.postmanUrl, e); }}'>
+                      ${postmanIcon()}
+                      View Postman collection
+                    </button>
+                </div></div>` : ''}
+          </div>
           <div id="api-title" part="section-overview-title" style="font-size:32px">
             ${this.resolvedSpec.info.title}
             ${!this.resolvedSpec.info.version ? '' : html`


### PR DESCRIPTION
#### What is the purpose of this pull request?

To update the overview template.

#### What problem is this solving?

The postman download button did not appear in overview pages.

#### How should this be manually tested?

Open any API Reference overview pages in the preview and check if the buttons appear on the top of the page.

#### Screenshots or example usage

<img width="676" alt="image" src="https://github.com/vtexdocs/devportal/assets/62757720/6b733f49-b585-42ae-9ba2-a716e8aeb5c9">

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
