### PR TITLE
Fix/header auth

### DIFF
--- a/src/components/api-request.js
+++ b/src/components/api-request.js
@@ -1053,6 +1053,7 @@ export default class ApiRequest extends LitElement {
       }
     }
     return html`
+      <button class='clear-btn m-btn m-btn-primary' style="margin-bottom: 16px" @click='${this.onTryClick}'>TEST METHOD</button>
       <button class="clear-btn m-btn m-btn-secondary" part="btn btn-outline" @click="${this.clearResponseData}">CLEAR RESPONSE</button>
       <div class="tab-panel col" style="border-top: 1px solid #E7E9EE; border-bottom: 1px solid #E7E9EE; margin-top: 24px;">
         ${this.codeExampleTemplate('flex')}

--- a/src/templates/security-scheme-template.js
+++ b/src/templates/security-scheme-template.js
@@ -2,6 +2,7 @@
 import { html } from 'lit';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js'; // eslint-disable-line import/extensions
 import { marked } from 'marked';
+import { isSecuritySchemeIdValid } from '../utils/security-utils';
 import updateCodeExample from '../utils/update-code-example';
 
 const codeVerifier = '731DB1C3F7EA533B85E29492D26AA-1234567890-1234567890';
@@ -396,10 +397,12 @@ function handleApiKeyChange(e, securitySchemeId, apiKey) {
 
 export default function securitySchemeTemplate() {
   if (!this.resolvedSpec) { return ''; }
+  if (this.security && this.security.length === 0) return '';
   const providedApiKeys = this.resolvedSpec.securitySchemes?.filter((v) => (v.finalKeyValue));
   if (!providedApiKeys) {
     return;
   }
+
   return html`
   <section id='auth' part="section-auth" class = 'row-api-right-box observe-me ${'read focused'.includes(this.renderStyle) ? 'section-gap--read-mode' : 'section-gap '}'>
     <div class="right-box-title">Header Auth</div>
@@ -407,7 +410,9 @@ export default function securitySchemeTemplate() {
     ${this.resolvedSpec.securitySchemes && this.resolvedSpec.securitySchemes.length > 0
       ? html`
         <div id="auth-table">
-          ${this.resolvedSpec.securitySchemes.map((v) => html`
+          ${this.resolvedSpec.securitySchemes.map((v) => {
+            if (!isSecuritySchemeIdValid(this.security, v.securitySchemeId)) return;
+            return html`
             <div id="security-scheme-${v.securitySchemeId}" class="right-box-container ${v.type.toLowerCase()}">
               <div class="right-box-label">${v.name}</div>
               ${v.description
@@ -483,7 +488,7 @@ export default function securitySchemeTemplate() {
                 `
               : ''
             }
-          `)}
+          `})}
         </div>`
       : ''
     }

--- a/src/templates/security-scheme-template.js
+++ b/src/templates/security-scheme-template.js
@@ -404,11 +404,10 @@ export default function securitySchemeTemplate() {
   }
 
   return html`
-  <section id='auth' part="section-auth" class = 'row-api-right-box observe-me ${'read focused'.includes(this.renderStyle) ? 'section-gap--read-mode' : 'section-gap '}'>
-    <div class="right-box-title">Header Auth</div>
-
     ${this.resolvedSpec.securitySchemes && this.resolvedSpec.securitySchemes.length > 0
       ? html`
+      <section id='auth' part="section-auth" class = 'row-api-right-box observe-me ${'read focused'.includes(this.renderStyle) ? 'section-gap--read-mode' : 'section-gap '}'>
+        <div class="right-box-title">Header Auth</div>
         <div id="auth-table">
           ${this.resolvedSpec.securitySchemes.map((v) => {
             if (!isSecuritySchemeIdValid(this.security, v.securitySchemeId)) return;
@@ -489,15 +488,11 @@ export default function securitySchemeTemplate() {
               : ''
             }
           `})}
-        </div>`
+        </div>
+        <slot name="auth"></slot>
+      </section>`
       : ''
     }
-    <button class='m-btn m-btn-primary' style="margin-top: 16px" @click='${this.onTryClick}' >
-      TEST METHOD
-    </button>
-    <slot name="auth">
-    </slot>
-  </section>
 `;
 }
 

--- a/src/utils/security-utils.js
+++ b/src/utils/security-utils.js
@@ -1,0 +1,12 @@
+
+export function isSecuritySchemeIdValid(security, securitySchemeId) {
+    if (!security) return true;
+    return security.some((securityObject) => {
+      return (
+        securityObject.hasOwnProperty(securitySchemeId) &&
+        Array.isArray(securityObject[securitySchemeId]) &&
+        securityObject[securitySchemeId].length === 0
+      );
+    });
+  }
+  

--- a/src/utils/update-code-example.js
+++ b/src/utils/update-code-example.js
@@ -1,5 +1,6 @@
 import HTTPSnippet from 'httpsnippet';
 import { json2xml } from './schema-utils';
+import { isSecuritySchemeIdValid } from './security-utils'
 
 function buildFetchURL(requestPanelEl) {
   let fetchUrl = this.path;
@@ -333,10 +334,12 @@ function buildFetchHeaders(requestPanelEl) {
     headers.push({ name: 'Content-Type', value: requestBodyContainerEl.dataset.selectedRequestBodyType });
   }
 
-  // Add Authentication Header if provided
+  // Add Authentication Header if provided and necessary
   this.resolvedSpec.securitySchemes.forEach((key) => {
-    reqHeaders.append(key.name, key.value);
-    headers.push({ name: key.name, value: key.value });
+    if (isSecuritySchemeIdValid(this.security, key.securitySchemeId)) {
+      reqHeaders.append(key.name, key.value);
+      headers.push({ name: key.name, value: key.value });
+    }
   });
 
   return { reqHeaders, headers };


### PR DESCRIPTION
#### What is the purpose of this pull request?

To hide the Header Auth section when authentication is not required.

#### What problem is this solving?

The API Reference page did not follow the specifications in the open API file.

#### How should this be manually tested?

Open the API Reference pages of endpoints that do not require authentication, such as [List Payment Provider Manifest](https://deploy-preview-447--elated-hoover-5c29bf.netlify.app/docs/api-reference/payment-provider-protocol#get-/manifest) and [Get list of the 10 most searched terms](https://deploy-preview-447--elated-hoover-5c29bf.netlify.app/docs/api-reference/intelligent-search-api#get-/top_searches) and verify the section Header Auth does not appear. Also, check if pages that require authentication still have that section.

#### Screenshots or example usage

| Before | After |
| --- | --- |
| ![image](https://github.com/vtexdocs/devportal/assets/62757720/f9a6c490-25f8-4ce7-8cfd-28b3517dc3ef) | ![image](https://github.com/vtexdocs/devportal/assets/62757720/2199deca-ad89-4736-baae-db0438000037) |

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
