### PR TITLE
fix: add expandable section in view render style

### DIFF
--- a/src/templates/endpoint-template.js
+++ b/src/templates/endpoint-template.js
@@ -171,7 +171,7 @@ function endpointBodyTemplate(path) {
           <content-copy-button id='${path.method}${path.path}' content='${joinURLandPath(this.selectedServer.url, path.path)}'></content-copy-button>
         </div>
       </div>
-      ${path.description ? html`<div part="section-endpoint-body-description" class="path-description"> ${unsafeHTML(path.description)}</div>` : ''}
+      ${path.description ? html`<div class="m-markdown"> ${unsafeHTML(marked(path.description))}</div>` : ''}
       <slot name="${path.elementId}"></slot>
       ${pathSecurityTemplate.call(this, path.security)}
       ${codeSampleTabPanel}
@@ -272,7 +272,7 @@ export default function endpointTemplate(showExpandCollapse = true, showTags = t
                 return true;
                 }).map((path) => html`
                 <section part="section-endpoint" id='${path.elementId}' class='m-endpoint regular-font ${path.method} ${pathsExpanded || path.expanded ? 'expanded' : 'collapsed'}'>
-                  <!--${endpointHeadTemplate.call(this, path, pathsExpanded)}-->
+                  ${endpointHeadTemplate.call(this, path, pathsExpanded)}
                   ${pathsExpanded || path.expanded ? endpointBodyTemplate.call(this, path) : ''}
                 </section>`)
               }


### PR DESCRIPTION
#### What is the purpose of this pull request?

To enable a complete view of OpenAPI (using view mode in render style).

Preview the _view mode_ [here](https://deploy-preview-464--elated-hoover-5c29bf.netlify.app/editor/openapi-preview?branch=master&file=VTEX%20-%20Catalog%20API.json)

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
