### PR TITLE
EDU-16758: fix focused-mode fallback when URL has no hash

### DIFF
--- a/src/rapidoc.js
+++ b/src/rapidoc.js
@@ -827,12 +827,24 @@ export default class RapiDoc extends LitElement {
   }
 
   /**
-   * From the URL return the ID of the element whether it is in the hash or if used a router prefix without a hash
+   * From the URL return the ID of the element whether it is in the hash or if used a router prefix without a hash.
+   *
+   * Bugfix: when the URL contains no hash AND no `?endpoint=` query, the
+   * `replace()` below returned the full href unchanged (because the
+   * `baseURL + routePrefix` substring was not present). That caused
+   * `scrollToPath(fullURL)` to set `focusedElementId` to a value that
+   * matches no path, forcing the focused template to fall back to the
+   * default (first) endpoint. Detect that the prefix actually exists in
+   * the URL before returning a non-empty id.
    */
   getElementIDFromURL() {
+    const { href } = window.location;
     const baseURL = this.getComponentBaseURL();
-    const elementId = window.location.href.replace(baseURL + this.routePrefix, '');
-    return elementId;
+    const prefix = `${baseURL}${this.routePrefix}`;
+    if (!href.startsWith(prefix) || href === baseURL) {
+      return '';
+    }
+    return href.slice(prefix.length);
   }
 
   replaceHistoryState(hashId) {

--- a/src/rapidoc.js
+++ b/src/rapidoc.js
@@ -827,15 +827,9 @@ export default class RapiDoc extends LitElement {
   }
 
   /**
-   * From the URL return the ID of the element whether it is in the hash or if used a router prefix without a hash.
-   *
-   * Bugfix: when the URL contains no hash AND no `?endpoint=` query, the
-   * `replace()` below returned the full href unchanged (because the
-   * `baseURL + routePrefix` substring was not present). That caused
-   * `scrollToPath(fullURL)` to set `focusedElementId` to a value that
-   * matches no path, forcing the focused template to fall back to the
-   * default (first) endpoint. Detect that the prefix actually exists in
-   * the URL before returning a non-empty id.
+   * Returns the element id encoded in the URL's hash or router prefix, or
+   * an empty string when the prefix isn't present (so callers don't get the
+   * full href and pass it to scrollToPath, which would mis-focus the doc).
    */
   getElementIDFromURL() {
     const { href } = window.location;


### PR DESCRIPTION
## Summary

When a focused-mode RapiDoc instance loads on a URL with no hash and no `?endpoint=` query, `getElementIDFromURL()` was returning the entire `href` instead of an empty id. That value was then passed to `scrollToPath()`, which set `focusedElementId` to a string that matched no path, forcing the focused-endpoint template to fall back to the default (first) endpoint and ignoring any subsequent programmatic `scrollToPath()` calls from the host page.

## Changes

- `src/rapidoc.js` — `getElementIDFromURL()` now checks that `baseURL + routePrefix` is actually a prefix of `window.location.href` before slicing. When it isn't (no hash, route prefix not present), it returns `''` so callers can decide what to focus instead of receiving a malformed id.

## Why

This bug surfaced in the VTEX Developers Portal API reference: deep links and same-slug client-side navigations between endpoints would render the first endpoint of the spec instead of the one named in the URL. The host page already calls `scrollToPath(...)` on every hash change, but the spec-(re)load path inside RapiDoc was overwriting `focusedElementId` with the full URL on every `attributeChangedCallback`, so the host's call was never visible. Returning an empty id here makes the host responsible for the initial focus (via `goto-path`) and lets subsequent `scrollToPath()` calls win.

## Related Task

[EDU-16758](https://vtex-dev.atlassian.net/browse/EDU-16758)
